### PR TITLE
Added region support to tf platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 bucket_name=terraform-states.nearsoft
 # Choose in case you have multiple profiles on your workstation
 aws_profile ?= nstask
+# Choose the AWS region to use
+aws_region ?=  us-east-1
 # Switch to different TF image version
 tf_versions ?= 0.12.29
 # Select platform
@@ -57,17 +59,17 @@ init:
 # Terraform plan
 .PHONY: plan
 plan:
-	$(TERRAFORM) plan -var 'aws_profile=$(aws_profile)' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
+	$(TERRAFORM) plan -var 'aws_profile=$(aws_profile)' -var 'aws_region=${aws_region}' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
 
 # Terraform apply
 .PHONY: apply
 apply:
-	$(TERRAFORM) apply -var 'aws_profile=$(aws_profile)' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
+	$(TERRAFORM) apply -var 'aws_profile=$(aws_profile)' -var 'aws_region=${aws_region}' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
 
 # Terraform destroy
 .PHONY: destroy
 destroy:
-	$(TERRAFORM) destroy -var 'aws_profile=$(aws_profile)' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
+	$(TERRAFORM) destroy -var 'aws_profile=$(aws_profile)' -var 'aws_region=${aws_region}' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
 
 # Build Terraform Ansible Docker image
 .PHONY: ansible-build
@@ -79,4 +81,5 @@ ansible-build:
 provision-wordpress:
 	export ENVIRONMENT="${app_env}"
 	export AWS_PROFILE="${aws_profile}"
+	export AWS_REGION="${aws_region}"
 	$(ANSIBLE)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ plan:
 # Terraform apply
 .PHONY: apply
 apply:
-	$(TERRAFORM) apply -var 'aws_profile=$(aws_profile)' -var 'aws_region=${aws_region}' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
+	$(TERRAFORM) apply  -var 'aws_profile=$(aws_profile)' -var 'aws_region=${aws_region}' -var 'app_env=${app_env}' -var-file=vars_${app_env}.tfvars
 
 # Terraform destroy
 .PHONY: destroy
@@ -79,7 +79,5 @@ ansible-build:
 # Provision Wordpress and the MySQL server using ansible
 .PHONY: provision-wordpress
 provision-wordpress:
-	export ENVIRONMENT="${app_env}"
-	export AWS_PROFILE="${aws_profile}"
-	export AWS_REGION="${aws_region}"
+	sed "s/AWS_REGION_TO_REPLACE/${aws_region}/g" "${PWD}/platform/stateful-application/ansible/inventory/${app_env}/.inventory_aws_ec2.yml" > "${PWD}/platform/stateful-application/ansible/inventory/${app_env}/inventory_aws_ec2.yml"
 	$(ANSIBLE)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [ENCORA DEVOPS MODULAR TASK](#encora-devops-modular-task)
   - [Platform Levels](#platform-levels)
   - [Platform dependency](#platform-dependency)
+  - [AWS deployment](#aws-deployment)
   - [Platform creation steps](#platform-creation-steps)
   - [The stateful application](#the-stateful-application)
     - [General information](#general-information)
@@ -24,9 +25,13 @@
 2- k8s
 3- [ services-k8s, ops-k8s, stateful-application ]
 
+## AWS deployment
+
+All the infrastructure deploys by default on `us-east-1`. If you want to deploy on a different region pass the  `aws_region` parameter to `make`.
+
 ## Platform creation steps
 
-Once you have your AWS credentials on ~/.aws/credentials like this:
+Create a named profile for the AWS Command Line Interface (CLI).  Once you have your AWS credentials on `~/.aws/credentials` like this:
 
 ```bash
 [nstask]
@@ -34,10 +39,10 @@ aws_access_key_id=LAGALLETADEANIMALITOTIENEMUCHAPROTEINA
 aws_secret_access_key=12y3tamarindoonetwotreetamarindo
 ```
 
-Create the platforms one by one
-Where:
+Create the platforms one by one, where:
 
-- aws_profile = refers to your AWS profile credentials as you have them set on your workstation
+- aws_profile = refers to your AWS profile credentials as you have them set on your workstation.
+- aws_region = name of the AWS region where the infrastructure will be deployed
 - app_env = refers to an environment or the interviewed name
 - platform = the platform level you are going to create for the task
 
@@ -82,8 +87,7 @@ Follow these steps to deploy the application:
 Run the following commands to create one key pair for the evaluator.
 
 ```bash
-$ cd platform/stateful-application
-$ ssh-keygen -t rsa -b 4096 -N "" -f files/id_rsa_evaluator
+$ ssh-keygen -t rsa -b 4096 -N "" -f platform/stateful-application/files/id_rsa_evaluator
 ```
 
 These commands create the key pairs under `files` directory:
@@ -100,7 +104,7 @@ Note: This key pair will be used by ansible to provision the Wordpress and MySQL
 
 2. Crear AWS CLI profile
 
-```
+```bash
 $ aws configure --profile <PROFILE_NAME>
 ```
 
@@ -108,7 +112,6 @@ $ aws configure --profile <PROFILE_NAME>
 
 - Table name: `terraform_states`
 - Tabke key: `LockID`
-
 
 4. Create a S3 bucket and the directories structure required to store Terraform statefile
 

--- a/platform/cloud/main.tf
+++ b/platform/cloud/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2.0"
-  region  = "us-east-1"
+  region  = var.aws_region
   profile = var.aws_profile
 }
 

--- a/platform/cloud/templatevars.tf
+++ b/platform/cloud/templatevars.tf
@@ -1,7 +1,12 @@
+variable "aws_region" {
+  description = "AWS region to deploy"
+}
+
 variable "aws_profile" {
   description = "AWS Profile"
 }
 
 variable "app_env" {
+  description = "Application environment name"
   default = "dev"
 }

--- a/platform/k8s/main.tf
+++ b/platform/k8s/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2.0"
-  region  = "us-east-1"
+  region  = var.aws_region
   profile = var.aws_profile
 }
 

--- a/platform/k8s/templatevars.tf
+++ b/platform/k8s/templatevars.tf
@@ -1,7 +1,12 @@
+variable "aws_region" {
+  description = "AWS region to deploy"
+}
+
 variable "aws_profile" {
   description = "AWS Profile"
 }
 
 variable "app_env" {
+  description = "Application environment name"
   default = "dev"
 }

--- a/platform/ops-k8s/maint.tf
+++ b/platform/ops-k8s/maint.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2.0"
-  region  = "us-east-1"
+  region  = var.aws_region
   profile = var.aws_profile
 }
 

--- a/platform/ops-k8s/templatevars.tf
+++ b/platform/ops-k8s/templatevars.tf
@@ -1,7 +1,12 @@
+variable "aws_region" {
+  description = "AWS region to deploy"
+}
+
 variable "aws_profile" {
   description = "AWS Profile"
 }
 
 variable "app_env" {
+  description = "Application environment name"
   default = "dev"
 }

--- a/platform/services-k8s/maint.tf
+++ b/platform/services-k8s/maint.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2.0"
-  region  = "us-east-1"
+  region  = var.aws_region
   profile = var.aws_profile
 }
 

--- a/platform/services-k8s/templatevars.tf
+++ b/platform/services-k8s/templatevars.tf
@@ -1,7 +1,12 @@
+variable "aws_region" {
+  description = "AWS region to deploy"
+}
+
 variable "aws_profile" {
   description = "AWS Profile"
 }
 
 variable "app_env" {
+  description = "Application environment name"
   default = "dev"
 }

--- a/platform/stateful-application/ansible/inventory/junior-h/.inventory_aws_ec2.yml
+++ b/platform/stateful-application/ansible/inventory/junior-h/.inventory_aws_ec2.yml
@@ -3,7 +3,7 @@ plugin: aws_ec2
 boto_profile: junior-h
 
 regions:
-  - us-east-1
+  - AWS_REGION_TO_REPLACE
 
 strict: False
 

--- a/platform/stateful-application/main.tf
+++ b/platform/stateful-application/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2.0"
-  region  = "us-east-1"
+  region  = var.aws_region
   profile = var.aws_profile
 }
 

--- a/platform/stateful-application/templatevars.tf
+++ b/platform/stateful-application/templatevars.tf
@@ -1,7 +1,12 @@
+variable "aws_region" {
+  description = "AWS region to deploy"
+}
+
 variable "aws_profile" {
   description = "AWS Profile"
 }
 
 variable "app_env" {
+  description = "Application environment name"
   default = "dev"
 }

--- a/platform/stateful-application/vars_junior-h.tfvars
+++ b/platform/stateful-application/vars_junior-h.tfvars
@@ -1,2 +1,0 @@
-aws_profile = "nstask"
-app_env = "junior-h"


### PR DESCRIPTION
Major changes:
- Added support to specify the AWS region to use for deployment for Terraform.

Minor changes:
- Improved documentation.
- Removed hardcoded vars from stateful-application configuration file on Terraform

Note:
- I didn't remove hardcoded region names from Kubernetes ALB as I'm not familiarized with that part of the infrastructure:

```bash
(virtualenv) Alfredos-MacBook-Pro:nstsk nsl-acambera$ pwd
/Users/nsl-acambera/code/encora/nstsk
(virtualenv) Alfredos-MacBook-Pro:nstsk nsl-acambera$ find . -type f -name "*.tf" -exec grep -inH us-east-1 {} \; |grep -v backend
./modules/alb-ingress-k8s/main.tf:163:        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/B9C1FDFF21CF68957E72BAF28E54E005"
./modules/alb-ingress-k8s/main.tf:168:          "oidc.eks.us-east-1.amazonaws.com/id/B9C1FDFF21CF68957E72BAF28E54E005:sub": "system:serviceaccount:kube-system:alb-ingress-controller-aws-alb-ingress-controller"
./modules/alb-ingress-k8s/main.tf:204:    value = "us-east-1"
```